### PR TITLE
Enhancement: Add suggestion for take() modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ $faker = Factory::create();
 $faker->withUnique()->name();
 $faker->withMaybe(0.8)->name();
 $faker->withValid(fn($v) => strlen($v) > 3))->name();
+$faker->take(5)->name(); // returns 5 names
 ```
 
 We can keep the modifier as Proxy classes like they are in 1.0.


### PR DESCRIPTION
This PR

* [x] adds a suggestion for a `take()` modifier

💁 A similar implementation in user-land code as of the moment would be

```php
<?php

$names = [
    $faker->firstName,
    $faker->firstName,
    $faker->firstName,
    $faker->firstName,
    $faker->firstName,
];
```

or

```php
<?php

$names = [];

for ($i = 0; $i < 5, ++$i) {
    $names[] = $faker->firstName;
];
```

or

```php
<?php

$names = array_map(static function () use ($faker): string {
    return $faker->firstName;
), range(0, 4));
```

❗ Note that in the last example, static code analysis tools usually complain because the closure does not use the argument as a parameter that is passed to it.

Also see https://github.com/fzaninotto/Faker/pull/710.
